### PR TITLE
Fix gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -226,7 +226,7 @@
     rebase=false
 [push]
     default=current
-    gpgSign=true
+    gpgSign=false # 2018年にサポートしなくなっている
 [rebase]
     stat=false
     autoSquash=false

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,7 +1,7 @@
 [user]
     name = onesword0618
     email = ao.akua.leo@gmail.com
-    signingkey = E2F30CEB4AEE75BE
+    signingkey = 5AFBEB0A92CA623F
 [advice]
     fetchShowForcedUpdates = true
     # git-fetchの強制更新で時間がかかっている場合の警告


### PR DESCRIPTION
事象
    git push を実行したときにエラーがでていた

```
fatal: the receiving end does not support --signed push
```
コミュニティの回答は以下。
https://github.community/t/push-signed/938